### PR TITLE
fix: mentors metadata cache

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -132,8 +132,9 @@ export interface CycleDistrictUdiseRow {
   udise: number;
 }
 
-export function CacheKeyMetadataAll() {
-  return `metadata*`;
+export function CacheKeyMetadataAll(actorId?: ActorEnum) {
+  if (actorId) return `metadata:${ActorEnum[actorId]}`;
+  return `metadata`;
 }
 
 export function CacheKeyMetadata(app_version_code: any, actorId?: ActorEnum) {


### PR DESCRIPTION
Cache service does have not  any wildcard or elastic key search, So modified the method to get all keys matching with a given name pattern and then remove that cache values.